### PR TITLE
On master: Issue 13 Some lights are not found

### DIFF
--- a/src/LifxNet/LifxClient.Discovery.cs
+++ b/src/LifxNet/LifxClient.Discovery.cs
@@ -10,7 +10,7 @@ namespace LifxNet
 {
 	public partial class LifxClient : IDisposable
 	{
-		private static uint identifier = 1;
+		private static uint identifier = 2;
 		private static object identifierLock = new object();
 		private UInt32 discoverSourceID;
 		private CancellationTokenSource? _DiscoverCancellationSource;


### PR DESCRIPTION
Changing initial identifier value from 1 to 2 to match with the documentation of the Lifx LAN API FrameHeader's source field. (ref: https://lan.developer.lifx.com/docs/packet-contents#frame-header)

Addresses Issue #13 